### PR TITLE
Multidomain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yarn-error.log
 public/google*.html
 report.html
 composer.phar
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 .env
+.env.sub.*
 public/google*.html
 report.html
 composer.phar

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -95,6 +95,11 @@ class Handler extends ExceptionHandler
         if ($exception instanceof FireflyException || $exception instanceof ErrorException || $exception instanceof OAuthServerException) {
             $isDebug = config('app.debug');
 
+            if ($isDebug) {
+                // Show a proper exception view ...
+                return parent::render($request, $exception);
+            }
+
             return response()->view('errors.FireflyException', ['exception' => $exception, 'debug' => $isDebug], 500);
         }
 

--- a/app/Helpers/WhitelabelHelper.php
+++ b/app/Helpers/WhitelabelHelper.php
@@ -1,0 +1,11 @@
+<?php
+
+if (!function_exists('whitelabelconfig')) {
+    function whitelabelconfig(string $name, $default = null) {
+        $config = \FireflyIII\Support\Facades\WhitelabelConfig::get($name, $default);
+        if ($config === null) {
+            return null;
+        }
+        return $config->value;
+    }
+}

--- a/app/Http/Middleware/Whitelabel.php
+++ b/app/Http/Middleware/Whitelabel.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace FireflyIII\Http\Middleware;
+
+use Closure;
+use FireflyIII\Models\WhitelabelConfig;
+use FireflyIII\Support\WhitelabelConfiguration;
+
+class Whitelabel
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $domain = $request->getHost();
+
+        /** @var \FireflyIII\Models\Whitelabel $whitelabel */
+        $whitelabel = \FireflyIII\Models\Whitelabel::where('domain', $domain)
+            ->where('active', true)
+            ->first();
+        if ($whitelabel !== null) {
+            app()->singleton(\FireflyIII\Models\Whitelabel::class, $whitelabel);
+            app()->singleton(WhitelabelConfiguration::class, function () use ($whitelabel) {
+                return new WhitelabelConfiguration($whitelabel);
+            });
+
+            // Overwrite existing config
+            foreach ($whitelabel->config as $config) {
+                /** @var WhitelabelConfig $config */
+                config([$config->name => $config->value]);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Whitelabel.php
+++ b/app/Models/Whitelabel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FireflyIII\Models;
+
+use Barryvdh\LaravelIdeHelper\Eloquent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @mixin Eloquent
+ * Class Whitelabel
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $domain
+ * @property boolean $active
+*/
+class Whitelabel extends Model
+{
+
+    public $timestamps = true;
+
+    protected $casts = [
+        'active' => 'boolean'
+    ];
+
+    public function config(): HasMany
+    {
+        return $this->hasMany(WhitelabelConfig::class, 'whitelabel_id', 'id');
+    }
+}

--- a/app/Models/WhitelabelConfig.php
+++ b/app/Models/WhitelabelConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace FireflyIII\Models;
+
+use Barryvdh\LaravelIdeHelper\Eloquent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @mixin Eloquent
+ * Class WhitelabelConfig
+ *
+ * @property int $whitelabel_id
+ * @property string $name
+ * @property string $value
+*/
+class WhitelabelConfig extends Model
+{
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime'
+    ];
+
+    public function whitelabel(): BelongsTo
+    {
+        return $this->belongsTo(Whitelabel::class, 'whitelabel_id', 'id');
+    }
+
+    public function getValueAttribute($value)
+    {
+        return json_decode($value);
+    }
+
+    public function setValueAttribute($value): void
+    {
+        $this->attributes['value'] = json_encode($value);
+    }
+}

--- a/app/Providers/WhitelabelServiceProvider.php
+++ b/app/Providers/WhitelabelServiceProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace FireflyIII\Providers;
+
+use FireflyIII\Support\WhitelabelConfiguration;
+use Illuminate\Support\ServiceProvider;
+
+class WhitelabelServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->bind(
+            'whitelabelconfig',
+            WhitelabelConfiguration::class
+        );
+    }
+}

--- a/app/Support/Facades/WhitelabelConfig.php
+++ b/app/Support/Facades/WhitelabelConfig.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FireflyIII\Support\Facades;
+
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @codeCoverageIgnore
+ * Class WhitelabelConfig
+ * @method null|\FireflyIII\Models\WhitelabelConfig get($name, $default = null)
+ * @method \FireflyIII\Models\WhitelabelConfig set(string $name, $value)
+ * @method delete(string $name)
+ * @method \FireflyIII\Models\WhitelabelConfig|null getFresh(string $name, $default = null)
+ * @method \FireflyIII\Models\WhitelabelConfig put(string $name, $value)
+*/
+class WhitelabelConfig extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'whitelabelconfig';
+    }
+}

--- a/app/Support/WhitelabelConfiguration.php
+++ b/app/Support/WhitelabelConfiguration.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace FireflyIII\Support;
+
+use FireflyIII\Models\Whitelabel;
+use Illuminate\Support\Facades\Cache;
+
+class WhitelabelConfiguration
+{
+    /** @var Whitelabel $whitelabel */
+    public $whitelabel;
+
+    public $cachePrefix = '';
+
+    public function __construct(Whitelabel $whitelabel = null)
+    {
+        if ($whitelabel === null) {
+            $whitelabel = Whitelabel::first();
+        }
+        $this->whitelabel = $whitelabel;
+        $this->cachePrefix = 'wl-'.$this->whitelabel->id.'-';
+    }
+
+    public function delete(string $name): void
+    {
+        if (Cache::has($this->cachePrefix . $name)) {
+            Cache::forget($this->cachePrefix . $name);
+        }
+
+        try {
+            $this->whitelabel->config()->where('name', $name)->delete();
+        } catch (\Exception $ex) {
+            //
+        }
+    }
+
+    public function get(string $name, $default = null): ?\FireflyIII\Models\WhitelabelConfig
+    {
+        if (Cache::has($this->cachePrefix . $name)) {
+            return Cache::get($this->cachePrefix . $name);
+        }
+
+        /** @var \FireflyIII\Models\WhitelabelConfig $config */
+        $config = $this->whitelabel->config()->where('name', $name)->first(['id', 'whitelabel_id', 'name', 'value']);
+
+        if ($config) {
+            Cache::forever($this->cachePrefix . $name, $config);
+
+            return $config;
+        }
+
+        if (null === $default) {
+            return null;
+        }
+
+        return $this->set($name, $default);
+    }
+
+    public function getFresh(string $name, $default = null): ?\FireflyIII\Models\WhitelabelConfig
+    {
+        /** @var \FireflyIII\Models\WhitelabelConfig $config */
+        $config = $this->whitelabel->config()->where('name', $name)->first(['id', 'whitelabel_id', 'name', 'value']);
+        if ($config) {
+            return $config;
+        }
+
+        if (null === $default) {
+            return null;
+        }
+
+        return $this->set($name, $default);
+    }
+
+    public function put(string $name, $value): \FireflyIII\Models\WhitelabelConfig
+    {
+        return $this->set($name, $value);
+    }
+
+    public function set(string $name, $value): \FireflyIII\Models\WhitelabelConfig
+    {
+        /** @var \FireflyIII\Models\WhitelabelConfig $config */
+        $config = $this->whitelabel->config()->where('name', $name)->first();
+        if (null === $config) {
+            $item = new \FireflyIII\Models\WhitelabelConfig;
+            $item->whitelabel_id = $this->whitelabel->id;
+            $item->name = $name;
+            $item->value = $value;
+            $item->save();
+
+            Cache::forget($this->cachePrefix . $name);
+
+            return $item;
+        }
+        $config->value = $value;
+        $config->save();
+
+        Cache::forget($this->cachePrefix . $name);
+
+        return $config;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -86,31 +86,6 @@ $app->singleton(
 
 /*
 |--------------------------------------------------------------------------
-| Overload environment, for the current domain
-|--------------------------------------------------------------------------
-|
-| We do this so we can use a single codebase, for multiple VHosts.
-| Each VHost can then overwrite all, or none, of the master environment
-| settings, to specify anything from a custom app name, to using a
-| different database.
-|
-*/
-if (!empty($_SERVER['HTTP_HOST'])) {
-    // Get the hostname, without TLD
-    $host = parse_url($_SERVER['HTTP_HOST'])['host'];
-    $host = explode('.', $host);
-    array_pop($host);
-    $domainNoTLD = implode('.', $host);
-    // We expect to find a environment file, named in the format of .env.sub.%hostname%
-    // within the application root
-    $envFile = realpath(__DIR__ . '/../.env.sub.' . $domainNoTLD);
-    if (false !== $envFile && file_exists($envFile)) {
-        \Dotenv\Dotenv::create('/../', $envFile)->overload();
-    }
-}
-
-/*
-|--------------------------------------------------------------------------
 | Return The Application
 |--------------------------------------------------------------------------
 |

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -86,6 +86,31 @@ $app->singleton(
 
 /*
 |--------------------------------------------------------------------------
+| Overload environment, for the current domain
+|--------------------------------------------------------------------------
+|
+| We do this so we can use a single codebase, for multiple VHosts.
+| Each VHost can then overwrite all, or none, of the master environment
+| settings, to specify anything from a custom app name, to using a
+| different database.
+|
+*/
+if (!empty($_SERVER['HTTP_HOST'])) {
+    // Get the hostname, without TLD
+    $host = parse_url($_SERVER['HTTP_HOST'])['host'];
+    $host = explode('.', $host);
+    array_pop($host);
+    $domainNoTLD = implode('.', $host);
+    // We expect to find a environment file, named in the format of .env.sub.%hostname%
+    // within the application root
+    $envFile = realpath(__DIR__ . '/../.env.sub.' . $domainNoTLD);
+    if (false !== $envFile && file_exists($envFile)) {
+        \Dotenv\Dotenv::create('/../', $envFile)->overload();
+    }
+}
+
+/*
+|--------------------------------------------------------------------------
 | Return The Application
 |--------------------------------------------------------------------------
 |

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,9 @@
   "suggest": {
   },
   "autoload": {
+    "files": [
+      "app/Helpers/WhitelabelHelper.php"
+    ],
     "classmap": [
       "database/seeds",
       "database/factories"

--- a/config/app.php
+++ b/config/app.php
@@ -97,6 +97,7 @@ return [
         FireflyIII\Providers\TagServiceProvider::class,
         FireflyIII\Providers\AdminServiceProvider::class,
         FireflyIII\Providers\RecurringServiceProvider::class,
+        FireflyIII\Providers\WhitelabelServiceProvider::class,
 
 
     ],
@@ -144,6 +145,7 @@ return [
         'Steam'         => \FireflyIII\Support\Facades\Steam::class,
         'ExpandedForm'  => \FireflyIII\Support\Facades\ExpandedForm::class,
         'Google2FA'     => PragmaRX\Google2FALaravel\Facade::class,
+        'WhitelabelConfig' => \FireflyIII\Support\Facades\WhitelabelConfig::class
 
     ],
 

--- a/database/migrations/2019_07_05_085017_create_whitelabels_table.php
+++ b/database/migrations/2019_07_05_085017_create_whitelabels_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateWhitelabelsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasTable('whitelabels')) {
+            Schema::create('whitelabels', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('name', 50);
+                $table->string('domain', 100)->index();
+                $table->boolean('active');
+                $table->timestamps();
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('whitelabels');
+    }
+}

--- a/database/migrations/2019_07_05_085322_create_whitelabel_configs_table.php
+++ b/database/migrations/2019_07_05_085322_create_whitelabel_configs_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateWhitelabelConfigsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!Schema::hasTable('whitelabel_configs')) {
+            Schema::create('whitelabel_configs', function (Blueprint $table) {
+                $table->increments('id');
+                $table->unsignedInteger('whitelabel_id');
+                $table->string('name', 100)->index();
+                $table->string('value', 240);
+
+                $table->unique(['whitelabel_id', 'name']);
+                $table->foreign('whitelabel_id')->references('id')->on('whitelabels')->onDelete('cascade');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('whitelabel_configs');
+    }
+}

--- a/resources/views/v1/layout/guest.twig
+++ b/resources/views/v1/layout/guest.twig
@@ -6,7 +6,7 @@
     <meta name="robots" content="noindex, nofollow, noarchive, noodp, NoImageIndex, noydir">
     <meta name="apple-mobile-web-app-capable" content="yes">
 
-    <title>Firefly III
+    <title>{{ config('app.name') }}
 
         {% if title != "Firefly" and title != "" %}
             // {{ title }}
@@ -46,7 +46,7 @@
 <body class="login-page">
 <div class="login-box">
     <div class="login-logo">
-        <a href="{{ route('index') }}"><b>Firefly</b>III</a>
+        <a href="{{ route('index') }}">{{ config('app.name') }}</a>
     </div>
     {% block content %}{% endblock %}
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@
 
 declare(strict_types=1);
 
+Route::group(['middleware' => \FireflyIII\Http\Middleware\Whitelabel::class], function() {
 
 Route::group(
     ['namespace' => 'FireflyIII\Http\Controllers\System',
@@ -1016,3 +1017,5 @@ Route::group(
 
 }
 );
+
+});


### PR DESCRIPTION
This uses the host domain to fetch a list of
config entries from the db, which then replaces the set config at
runtime.
The host is read in middleware, which for now is registered at the top
level, for all registered routes. We may wish to fine-tune that at some
point (so admin pages aren't affected, for example).

Fixes #1 